### PR TITLE
Add missing foreign functions for Data.Show

### DIFF
--- a/purescript-prelude/Data_Show.go
+++ b/purescript-prelude/Data_Show.go
@@ -2,8 +2,9 @@ package purescript_prelude
 
 import (
 	"fmt"
-	. "github.com/purescript-native/go-runtime"
 	"strings"
+
+	. "github.com/purescript-native/go-runtime"
 )
 
 func init() {
@@ -40,6 +41,25 @@ func init() {
 			}
 			result += "]"
 			return result
+		}
+	}
+
+	exports["cons"] = func(head_ Any) Any {
+		return func(tail_ Any) Any {
+			return append([]Any{head_}, tail_.([]Any)...)
+		}
+	}
+
+	exports["join"] = func(separator_ Any) Any {
+		return func(xs_ Any) Any {
+			xs := xs_.([]Any)
+			ss := make([]string, len(xs))
+			for i, x := range xs {
+				ss[i] = x.(string)
+			}
+
+			res := strings.Join(ss, separator_.(string))
+			return res
 		}
 	}
 

--- a/purescript-prelude/Record_Unsafe.go
+++ b/purescript-prelude/Record_Unsafe.go
@@ -7,6 +7,12 @@ import (
 func init() {
 	exports := Foreign("Record.Unsafe")
 
+	exports["unsafeGet"] = func(label_ Any) Any {
+		return func(rec_ Any) Any {
+			return rec_.(map[string]Any)[label_.(string)]
+		}
+	}
+
 	exports["unsafeSet"] = func(label_ Any) Any {
 		return func(value Any) Any {
 			return func(rec_ Any) Any {


### PR DESCRIPTION
Right now we can not use `Data.Show` class with nested records or arrays of records because some foreign functions are missing:

 * `Data.Show.cons`
 * `Data.Show.join`
 * `Record.Unsafe.unsageGet`

This PR adds these functions.