### PR TITLE
Handle Foreign int64s

### DIFF
--- a/purescript-foreign/Foreign.go
+++ b/purescript-foreign/Foreign.go
@@ -54,6 +54,9 @@ func init() {
 		case int:
 			return "Number"
 
+		case int64:
+			return "Number"
+
 		case bool:
 			return "Boolean"
 

--- a/purescript-integers/Data_Int.go
+++ b/purescript-integers/Data_Int.go
@@ -17,11 +17,18 @@ func init() {
 		return func(nothing Any) Any {
 			return func(n_ Any) Any {
 				just, _ := just_.(Fn)
-				n := n_.(float64)
-				if math.Round(n) == n {
-					return just(int(n))
-				} else {
-					return nothing
+				switch n_.(type) {
+				case int64:
+					return just(n_)
+				case int:
+					return just(n_)
+				default:
+					n := n_.(float64)
+					if math.Round(n) == n {
+						return just(int(n))
+					} else {
+						return nothing
+					}
 				}
 			}
 		}


### PR DESCRIPTION
I've had trouble running `read` from `simple-json`, so converting a value (that I was getting from a Database) to a Purescript type.

It looks like go inferred the type from the db to be an `int64` rather than an `int` which somehow ended up matching the `Any` branch, I think.

Anyway, with these changes it works. I don't really think they work, but I'm starting to wonder if there might be a point to add more types to `purescript-foreign`. They should just not really come up in JS code or JSON but the case of just going from `Foreign` to something in PS land would be greatly simplified. 