### PR TITLE
add zshr

### DIFF
--- a/purescript-integers/Data_Int_Bits.go
+++ b/purescript-integers/Data_Int_Bits.go
@@ -1,0 +1,15 @@
+package purescript_integers
+
+import (
+	. "github.com/purescript-native/go-runtime"
+)
+
+func init() {
+	exports := Foreign("Data.Int.Bits")
+
+	exports["zshr"] = func(n Any) Any {
+		return func (i Any) Any {
+			return int(uint(n.(int)) >> i.(int))
+		}
+	}
+}


### PR DESCRIPTION
This implements zshr as suggested here https://github.com/andyarvanitis/purescript-native/issues/65 by coercing the value to unsigned, shifting, and converting back. This works for 32 bit and 64 bit values, but this will be dependent on the system's architecture:

```purescript
log $ show $ Data.Int.Bits.zshr 2048 2
log $ show $ Data.Int.Bits.zshr 9223372036853775807 2
```

```bash
> ./Main --hello test
512
2305843009213443951  
``` 

I'm not sure I understand purescript-native's approach to numbers to be more confident in this implementation.